### PR TITLE
feat: 권한 변경 버튼 스타일 개선 (색상 및 테두리 변경)

### DIFF
--- a/src/main/resources/static/css/manageUser.css
+++ b/src/main/resources/static/css/manageUser.css
@@ -197,11 +197,13 @@
 
 /* 권한 변경 버튼 (기본 회색 스타일) */
 .btn-role-change {
-    color: #374151; /* 기본 텍스트 색상 */
+    color: var(--primary); /* 기본 파란색 */
+    border-color: var(--secondary); /* 연한 파란색 테두리 */
 }
 .btn-role-change:hover {
-    background-color: #f3f4f6;
-    border-color: #9ca3af;
+    color: #1e40af; /* 진한 파란색 */
+    background-color: #e0e7ff; /* 연한 파란색 배경 */
+    border-color: #a5b4fc; /* 중간 파란색 테두리 */
 }
 
 /* 활성화 버튼 (초록색 계열) */


### PR DESCRIPTION
This pull request updates the styling for the role change button in the `manageUser.css` file to use a blue color scheme, improving visual consistency with the application's theme.

Styling updates for role change button:

* Changed the default text color to use the primary blue color and updated the border color to use the secondary blue shade (`.btn-role-change`).
* Modified the hover state to use a darker blue text, a lighter blue background, and a medium blue border color for better visual feedback.