### PR TITLE
feat: SSE 알림 기능 추가 및 GlobalModel, NotificationController 수정

### DIFF
--- a/src/main/java/net/dsa/scitHub/controller/GlobalModel.java
+++ b/src/main/java/net/dsa/scitHub/controller/GlobalModel.java
@@ -20,7 +20,21 @@ import net.dsa.scitHub.service.UserService;
  * 전역 모델 주입
  * - 모든 뷰 렌더링 시 공통으로 필요한 값들을 내려줍니다.
  */
-@ControllerAdvice
+@ControllerAdvice(assignableTypes = {
+    AdminController.class,
+    ArchiveController.class,
+    CalendarApiController.class,
+    CalendarController.class,
+    CkEditor5Controller.class,
+    ClassroomController.class,
+    CommunityController.class,
+    HomeController.class,
+    MessageController.class,
+    MypageController.class,
+    NotificationReadController.class,
+    ReservationApiController.class,
+    UserController.class
+})
 @RequiredArgsConstructor
 @Slf4j
 public class GlobalModel {
@@ -39,7 +53,7 @@ public class GlobalModel {
 
         try {
             MypageDTO currentUserDTO = us.getMemberInfo(user.getUsername());
-            log.debug("currentUser injected: {}", currentUserDTO);
+            log.debug("현재 로그인 사용자: {}", currentUserDTO);
             model.addAttribute("currentUser", currentUserDTO);
 
             if (currentUserDTO != null) {
@@ -48,7 +62,7 @@ public class GlobalModel {
 
                 model.addAttribute("unreadCount", unreadCount);
                 model.addAttribute("notifications", notifications);
-                log.debug("Notification data injected: unreadCount={}, notificationSize={}", unreadCount, notifications.size());
+                log.debug("알림 데이터 주입됨: unreadCount={}, notificationSize={}", unreadCount, notifications.size());
             }
         } catch (Exception e) {
             log.warn("글로벌 모델 주입 중 오류 발생", e);

--- a/src/main/java/net/dsa/scitHub/controller/NotificationReadController.java
+++ b/src/main/java/net/dsa/scitHub/controller/NotificationReadController.java
@@ -1,0 +1,29 @@
+package net.dsa.scitHub.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.dsa.scitHub.service.NotificationService;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationReadController {
+
+    private final NotificationService ns;
+
+    @PostMapping("/notifications/read/{notificationId}")
+    public ResponseEntity<Void> markAsRead(@PathVariable("notificationId") Integer notificationId) {
+        log.debug("notificationId가 {}로 설정되었습니다.", notificationId);
+
+        // 알림을 '읽음' 상태로 업데이트
+        ns.markAsRead(notificationId);
+
+        // 성공적으로 처리되었음을 알리는 200 OK 응답 반환
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/net/dsa/scitHub/repository/board/SseEmitterRepository.java
+++ b/src/main/java/net/dsa/scitHub/repository/board/SseEmitterRepository.java
@@ -1,0 +1,30 @@
+package net.dsa.scitHub.repository.board;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Repository
+@Slf4j
+public class SseEmitterRepository {
+
+    private final Map<Integer, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    public void save(Integer userId, SseEmitter emitter) {
+        emitters.put(userId, emitter);
+        log.info("SseEmitter 저장됨 [userId={}]", userId);
+    }
+
+    public void deleteById(Integer userId) {
+        emitters.remove(userId);
+        log.info("SseEmitter 삭제됨 [userId={}]", userId);
+    }
+
+    public SseEmitter findById(Integer userId) {
+        return emitters.get(userId);
+    }
+}

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -249,6 +249,7 @@
                     const list = document.getElementById('notification-list');
                     const newLi = document.createElement('li');
                     newLi.className = 'is-unread'; // 새로 온 알림은 항상 '읽지 않음'
+                    newLi.dataset.notificationId = noti.notificationId;
 
                     // 서버에서 받은 시간으로 "time ago" 텍스트 생성 (TimeUtil 로직을 JS로 구현)
                     const timeAgoText = formatTimeAgo(noti.createdAt);
@@ -257,7 +258,7 @@
                     const fullTargetUrl = ctx + noti.targetUrl;
 
                     newLi.innerHTML = `
-                        <a href="${fullTargetUrl}">
+                        <a href="${fullTargetUrl}" class="notification-link" data-notification-id="${noti.notificationId}">
                             <strong class="noti-title">${noti.title}</strong>
                             <p class="noti-content">${noti.content}</p>
                             <span class="noti-time" title="${fullTimeText}">${timeAgoText}</span>


### PR DESCRIPTION
This pull request refactors and improves the notification system, particularly the server-sent events (SSE) handling for real-time notifications. It introduces a dedicated repository for managing SSE emitters, separates notification read logic into its own controller, and cleans up related service and controller logic for better maintainability and clarity.

**SSE Notification System Refactoring:**

* Introduced `SseEmitterRepository` to centrally manage SSE emitters for each user, replacing the previous in-memory map in `NotificationService`. This repository provides methods to save, retrieve, and delete emitters.
* Refactored `NotificationService` to use `SseEmitterRepository` for emitter management, removing the static map and related logic. Now, real-time notifications are sent directly via the repository-managed emitter, and transactional annotations were added for read-only queries. [[1]](diffhunk://#diff-a066eff8ba22d2c59f382cd4696402ad84c4528133db095929d773e0ebb7a910R23-R41) [[2]](diffhunk://#diff-a066eff8ba22d2c59f382cd4696402ad84c4528133db095929d773e0ebb7a910L128-R71) [[3]](diffhunk://#diff-a066eff8ba22d2c59f382cd4696402ad84c4528133db095929d773e0ebb7a910R239) [[4]](diffhunk://#diff-a066eff8ba22d2c59f382cd4696402ad84c4528133db095929d773e0ebb7a910R251)
* Updated `NotificationController` to handle SSE subscriptions using the repository, set up emitter lifecycle callbacks, and provide immediate feedback to the client on connection. [[1]](diffhunk://#diff-c79c59d543608266853e887d0ade5ecd7fac98d2b61a73ea33034c5eec2c1655L4-R11) [[2]](diffhunk://#diff-c79c59d543608266853e887d0ade5ecd7fac98d2b61a73ea33034c5eec2c1655R20-R21) [[3]](diffhunk://#diff-c79c59d543608266853e887d0ade5ecd7fac98d2b61a73ea33034c5eec2c1655L34-R49)

**Controller and Endpoint Improvements:**

* Moved the notification "mark as read" endpoint to a new `NotificationReadController` for better separation of concerns.
* Updated `GlobalModel` to inject itself only into specific controllers (using `assignableTypes`) and localized log messages to Korean for consistency. [[1]](diffhunk://#diff-31af7e961ca6ec375bc1d38c07b8faff6c0a10b01ceeed366719d2d50eab5331L23-R37) [[2]](diffhunk://#diff-31af7e961ca6ec375bc1d38c07b8faff6c0a10b01ceeed366719d2d50eab5331L42-R56) [[3]](diffhunk://#diff-31af7e961ca6ec375bc1d38c07b8faff6c0a10b01ceeed366719d2d50eab5331L51-R65)

**Frontend Integration:**

* Modified the notification sidebar template to include `data-notification-id` attributes on notification elements and links, facilitating client-side handling such as marking notifications as read. [[1]](diffhunk://#diff-aa505945e7f46272b109d4013a170e9548a51148d1f21a0361df49bf7dfb4febR252) [[2]](diffhunk://#diff-aa505945e7f46272b109d4013a170e9548a51148d1f21a0361df49bf7dfb4febL260-R261)