### PR TITLE
refactor: 게시판 URL에 현재 페이지와 검색 범위, 검색어 정보를 담도록 변경

### DIFF
--- a/src/main/resources/static/js/community/getPostListWithPaging.js
+++ b/src/main/resources/static/js/community/getPostListWithPaging.js
@@ -1,212 +1,201 @@
 $(document).ready(function () {
-    // hidden input 영역에서 boardId 추출
     const initialBoardId = $('#boardId').val();
 
-    // 1. 페이지 최초 로드
-    loadPosts(initialBoardId, 0);
+    // 1. 페이지 로드 시 URL에서 1-based 페이지 번호 복원
+    const urlParams = new URLSearchParams(window.location.search);
+    const searchType = urlParams.get('searchType');
+    const keyword = urlParams.get('keyword');
+    
+    // URL의 page 파라미터는 1-based. 없으면 1페이지.
+    const pageFromUrl = parseInt(urlParams.get('page')) || 1;
+    // 서버에 보낼 때는 0-based 인덱스로 변환
+    const pageForServer = pageFromUrl - 1;
+
+    if (searchType && keyword) {
+        // 검색창에 값 복원
+        $('#searchType').val(searchType);
+        $('#search-keyword').val(keyword);
+        // 저장된 조건으로 게시글 로드
+        loadPosts(initialBoardId, pageForServer, searchType, keyword);
+    } else {
+        // 기본 게시글 목록 로드
+        loadPosts(initialBoardId, pageForServer);
+    }
+
     translateBoardNameToJp();
 
-    // 2. 검색 버튼 클릭 이벤트
-    // 검색 버튼 클릭 시
-    $('#search-btn').on('click', searchPosts);
-    // 엔터 키 입력 시
+    // 2. 검색 버튼 및 엔터 키 이벤트
+    $('#search-btn').on('click', function() {
+        executeSearch(initialBoardId);
+    });
+
     $('#search-keyword').on('keydown', function(event) {
         if (event.key === 'Enter') {
             event.preventDefault();
-            searchPosts();
+            executeSearch(initialBoardId);
         }
     });
 });
 
-// 검색 이벤트와 바인딩된 함수
-function searchPosts() {
-    // hidden input 영역에서 boardId 추출
-    const boardId = $('#boardId').val();
+
+/**
+ * 검색을 실행하고 URL을 업데이트하는 함수
+ */
+function executeSearch(boardId) {
     const searchType = $('#searchType').val();
     const keyword = $('#search-keyword').val();
 
-    if (keyword.trim() === "") {
-        alert("検査ワードを入力して下さい。");
+    if (keyword.trim() === '') {
+        alert('検査ワードを入力して下さい。');
         return;
     }
-
-    // 검색 실행 시, 첫 페이지부터 조회
+    
+    // 검색 시 항상 서버에는 첫 페이지(0)를 요청하고, URL에는 1페이지로 표시
     loadPosts(boardId, 0, searchType, keyword);
 }
 
 /**
- * 게시판 이름을 일본어로 해석
+ * URL의 쿼리 스트링을 업데이트하는 함수 (1-based page)
+ * @param {number} userPage - 사용자에게 표시될 1-based 페이지 번호
  */
-function translateBoardNameToJp() {
-    const boardName = $('.boardName').text();
-    let result = '';
-    switch (boardName) {
-            case "free":
-                result = "自由掲示板";
-                break;
-            case "it":
-                result = "IT情報";
-                break;
-            case "japanese":
-                result = "日本語情報";
-                break;
-            case "jpCulture":
-                result = "日本文化&生活情報";
-                break;
-            case "job":
-                result = "就活情報&コツ";
-                break;
-            case "hobby":
-                result = "趣味&旅行&グルメ情報";
-                break;
-            case "certificate":
-                result = "資格情報";
-                break;
-            case "graduated":
-                result = "卒業生掲示板";
-                break;
-            default:
-                result = "掲示板の名前が間違っています";
-                break;
-        }
-    console.log(result);
-    $('.boardName').text(result);
+function updateURL(userPage, searchType = null, keyword = null) {
+    const url = new URL(window.location);
+    // URL에는 항상 1-based 페이지 번호를 설정
+    url.searchParams.set('page', userPage);
+
+    if (searchType && keyword) {
+        url.searchParams.set('searchType', searchType);
+        url.searchParams.set('keyword', keyword);
+    } else {
+        url.searchParams.delete('searchType');
+        url.searchParams.delete('keyword');
+    }
+    window.history.pushState({ path: url.href }, '', url.href);
 }
 
+
 /**
- * 게시글 목록 또는 검색 결과를 비동기적으로 로드
+ * 게시글 목록 또는 검색 결과를 비동기적으로 로드 (0-based page)
  * @param {number} boardId - 게시판 ID
- * @param {number} page - 페이지 번호
- * @param {string|null} searchType - 검색 유형 (예: 'title', 'author')
- * @param {string|null} keyword - 검색어
+ * @param {number} pageIndex - 서버에 요청할 0-based 페이지 인덱스
  */
-function loadPosts(boardId, page = 0, searchType = null, keyword = null) {
+function loadPosts(boardId, pageIndex = 0, searchType = null, keyword = null) {
+    // URL을 업데이트할 때는 1-based 페이지 번호로 변환
+    updateURL(pageIndex + 1, searchType, keyword);
+
     let requestData = {
         boardId: boardId,
-        page: page,
+        page: pageIndex, // 서버에는 0-based 인덱스 전송
         size: 10,
-        sort: ['createdAt,desc', 'postId, desc']
+        sort: ['createdAt,desc', 'postId,desc']
     };
 
-    // 검색 파라미터가 존재하면 data 객체에 추가
     if (searchType && keyword) {
         requestData.searchType = searchType;
         requestData.keyword = keyword;
     }
 
     $.ajax({
-        url: `getBoard`, // 동일한 엔드포인트 사용
+        url: 'getBoard',
         type: 'GET',
         data: requestData,
         dataType: 'json',
         success: function (pageData) {
             renderPosts(pageData.content);
-            // 페이지네이션에도 검색 상태를 전달
             renderPagination(pageData, boardId, searchType, keyword);
         },
         error: function (xhr, status, error) {
             console.error('データのロードに失敗しました:', error);
-            $('#post-list-body').html('<tr class="no-posts-message"><td colspan="6">データの読込み中エラーが生じました。</td></tr>');
+            $('#post-list-body').html('<tr class="no-posts-message"><td colspan="6">게시글을 불러오는 데 실패했습니다.</td></tr>');
         }
     });
 }
 
-/**
- * 게시글 데이터를 렌더링합니다. (이전과 동일)
- */
+// renderPosts, renderPagination, translateBoardNameToJp 함수는 이전과 동일하게 유지됩니다.
+
+function translateBoardNameToJp() {
+    const boardName = $('.boardName').text();
+    let result = '';
+    switch (boardName) {
+        case "free": result = "自由掲示板"; break;
+        case "it": result = "IT情報"; break;
+        case "japanese": result = "日本語情報"; break;
+        case "jpCulture": result = "日本文化&生活情報"; break;
+        case "job": result = "就活情報&コツ"; break;
+        case "hobby": result = "趣味&旅行&グルメ情報"; break;
+        case "certificate": result = "資格情報"; break;
+        case "graduated": result = "卒業生掲示板"; break;
+        default: result = "掲示板"; break;
+    }
+    $('.boardName').text(result);
+}
+
 function renderPosts(posts) {
     const $postListBody = $('#post-list-body');
     $postListBody.empty();
 
     if (!posts || posts.length === 0) {
-        $postListBody.html('<tr class="no-posts-message"><td colspan="6">表示するポストがありません。</td></tr>');
+        $postListBody.html('<tr class="no-posts-message"><td colspan="6">게시글이 없습니다.</td></tr>');
         return;
     }
 
     $.each(posts, function (index, post) {
+        const detailUrl = `readPost?postId=${post.postId}`;
+
         const postRow = `
             <tr>
                 <td class="post-title">
-                    <span class="postLink"
-                        onclick="location.href='readPost?postId=${post.postId}'">
-                        ${post.title}
-                    </span>
+                    <a class="postLink" href="${detailUrl}">${post.title}</a>
                 </td>
                 <td class="post-writer">${post.userNameKor}</td>
                 <td class="post-createdAt">${new Date(post.createdAt).toLocaleDateString()}</td>
                 <td class="post-viewCount">${post.viewCount}</td>
                 <td class="post-likeCount">${post.likeCount}</td>
                 <td class="post-commentCount">${post.commentCount}</td>
-            </tr>
-        `;
+            </tr>`;
         $postListBody.append(postRow);
     });
 }
 
-/**
- * 페이지네이션 UI 생성
- * - 고정된 페이지 블록과 맨 처음/맨 끝 이동 버튼을 포함합니다.
- *
- * @param {Page<PostDTO>} pageData - Spring의 Page 객체
- * @param {number} boardId - 현재 게시판 ID
- * @param {string|null} searchType - 현재 검색 유형
- * @param {string|null} keyword - 현재 검색어
- */
 function renderPagination(pageData, boardId, searchType, keyword) {
     const $pagination = $('#pagination-container');
     $pagination.empty();
 
-    // 표시할 데이터가 없으면 종료
     if (!pageData || pageData.totalPages === 0) {
         return;
     }
-
-    // 전체 페이지가 1개뿐인 경우, '1'을 현재 페이지로 표시하고 종료
     if (pageData.totalPages === 1) {
-        const $page1 = $('<b>').text(1).addClass('active');
-        $pagination.append($page1);
+        const page1 = $('<b>').text('1').addClass('active');
+        $pagination.append(page1);
         return;
     }
 
-    const currentPage = pageData.number;      // 현재 페이지 (0-indexed)
-    const totalPages = pageData.totalPages;    // 전체 페이지 수
-    const pagesPerBlock = 5;                  // 한 블록에 표시할 페이지 수
-
-    // 현재 페이지가 속한 블록의 시작과 끝 페이지를 계산
+    const currentPage = pageData.number;
+    const totalPages = pageData.totalPages;
+    const pagesPerBlock = 5;
     const currentBlock = Math.floor(currentPage / pagesPerBlock);
     const startPage = currentBlock * pagesPerBlock;
     const endPage = Math.min(startPage + pagesPerBlock - 1, totalPages - 1);
 
-    // '맨 처음' (<<) 버튼: 현재 페이지가 1, 2가 아닐 때만 표시
-    if (currentPage > 1) {
-        const $firstLink = $('<a>').html('&laquo;').on('click', () => loadPosts(boardId, 0, searchType, keyword));
-        $pagination.append($firstLink);
-    }
-
-    // '이전 페이지' (<) 버튼: 첫 페이지가 아닐 때만 표시
     if (currentPage > 0) {
-        const $prevPageLink = $('<a>').html('&lsaquo;').on('click', () => loadPosts(boardId, currentPage - 1, searchType, keyword));
-        $pagination.append($prevPageLink);
+        const firstLink = $('<a>').html('&laquo;').on('click', () => loadPosts(boardId, 0, searchType, keyword));
+        $pagination.append(firstLink);
+        const prevPageLink = $('<a>').html('&lsaquo;').on('click', () => loadPosts(boardId, currentPage - 1, searchType, keyword));
+        $pagination.append(prevPageLink);
     }
 
-    // 페이지 번호 버튼 렌더링 (블록 단위)
     for (let i = startPage; i <= endPage; i++) {
         const pageNum = i;
-        const $pageLink = (pageNum === currentPage)
-            ? $('<b>').text(pageNum + 1).addClass('active')
-            : $('<a>').text(pageNum + 1).on('click', () => loadPosts(boardId, pageNum, searchType, keyword));
-        $pagination.append($pageLink);
+        const pageLink = (pageNum === currentPage) ?
+            $('<b>').text(pageNum + 1).addClass('active') :
+            $('<a>').text(pageNum + 1).on('click', () => loadPosts(boardId, pageNum, searchType, keyword));
+        $pagination.append(pageLink);
     }
 
-    // '다음 페이지' (>) 버튼: 마지막 페이지가 아닐 때만 표시
     if (currentPage < totalPages - 1) {
-        const $nextPageLink = $('<a>').html('&rsaquo;').on('click', () => loadPosts(boardId, currentPage + 1, searchType, keyword));
-        $pagination.append($nextPageLink);
-    }
-
-    // '맨 끝' (>>) 버튼: 마지막 또는 마지막 전 페이지가 아닐 때만 표시
-    if (currentPage < totalPages - 2) {
-        const $lastLink = $('<a>').html('&raquo;').on('click', () => loadPosts(boardId, totalPages - 1, searchType, keyword));
-        $pagination.append($lastLink);
+        const nextPageLink = $('<a>').html('&rsaquo;').on('click', () => loadPosts(boardId, currentPage + 1, searchType, keyword));
+        $pagination.append(nextPageLink);
+        const lastLink = $('<a>').html('&raquo;').on('click', () => loadPosts(boardId, totalPages - 1, searchType, keyword));
+        $pagination.append(lastLink);
     }
 }

--- a/src/main/resources/static/js/community/readPostInit.js
+++ b/src/main/resources/static/js/community/readPostInit.js
@@ -1,8 +1,35 @@
 $(document).ready(function() {
-    // 뒤로 가기 버튼
-    $('.back-arrow').click(function() {
-        const board = $('#board').val();
-        location.href = `board?name=${board}`
+    /**
+     * 뒤로가기 버튼 이벤트 처리
+     * - 이전 페이지가 글쓰기('/writePost')이면, 해당 게시판의 첫 페이지로 이동
+     * - 이전 페이지가 글쓰기('/writePost')가 아니고 이전 페이지 이력이 있다면 , 검색 상태가 유지된 채로 뒤로가기
+     */
+    $('.back-arrow').click(function(e) {
+        e.preventDefault(); // <a> 태그의 기본 링크 이동 동작 방지
+
+        const referrer = document.referrer;
+        const boardName = $('#board').val(); // hidden input에서 게시판 이름 가져오기
+
+        // 1. 이전 페이지 URL(referrer) 정보가 있는지 확인
+        if (referrer) {
+            const previousUrl = new URL(referrer);
+
+            // 이전 페이지가 글쓰기 페이지('/writePost')인 경우
+            if (previousUrl.pathname.includes('/writePost')) {
+                // 해당 게시판의 기본 목록 페이지로 이동
+                location.href = `board?name=${boardName}`;
+            }
+            // 4. 그 외 다른 페이지에서 넘어온 경우
+            else {
+                // 일반적인 뒤로가기 동작 수행
+                history.back();
+            }
+        }
+        // 5. Referrer 정보가 없는 경우 (북마크나 URL 직접 입력으로 접속한 경우)
+        else {
+            // 기본 동작으로 게시판 목록으로 이동
+            location.href = `board?name=${boardName}`;
+        }
     });
 
     // 댓글 목록 가져오기


### PR DESCRIPTION
🟠우선순위 중

- [x]  게시판에서 검색 후에 새로고침을 하면 검색하지 않은 상태로 돌아감 (URL에 검색 관련 속성이 들어가도록 수정해서 해결)
- [x]  검색 수행 후 특정 게시글에 접속하고 뒤로가기 버튼을 눌러 이동했을 때, 검색 결과가 보이지 않음 (History API를 이용한 이전 URL 분기 처리로 해결)

🟢우선순위 하

- [x]  1번 페이지가 아닌 페이지에서 글을 하나 보고 뒤로 가면 1번 페이지로 돌아가 있음. 내가 있던 페이지 번호로 돌아가게 할 수 있나 (위와 같이 History API를 이용한 이전 URL 추적으로 해결)