### PR TITLE
feat: 공지사항 보드에 다국어 지원 추가

### DIFF
--- a/src/main/resources/static/css/home.css
+++ b/src/main/resources/static/css/home.css
@@ -1,11 +1,11 @@
 /* ===================================================================
-   Refactored CSS for SCIT Hub (home.css) - UPDATED
-   - Inspired by modern, monochrome design with color accents.
-   - Applies a consistent token system for colors, fonts, and spacing.
+    Refactored CSS for SCIT Hub (home.css) - UPDATED
+    - Inspired by modern, monochrome design with color accents.
+    - Applies a consistent token system for colors, fonts, and spacing.
    =================================================================== */
 
 /* ----------------------------------
-   1. Root Variables & Base Styles (Tokens)
+    1. Root Variables & Base Styles (Tokens)
    ---------------------------------- */
 :root {
     /* Colors */
@@ -14,7 +14,7 @@
     --text-primary: #111827;     /* Main text color (Near Black) */
     --text-secondary: #6B7280;   /* Muted text for subtitles, hints */
     --border-color: #E5E7EB;     /* Standard border color */
-    
+
     /* Accent Colors (Inspired by reference images) */
     --accent-blue: #4F46E5;      /* A vibrant blue */
     --accent-green: #10B981;     /* A clear green */
@@ -36,13 +36,13 @@
     --border-radius-md: 12px;
     --border-radius-lg: 16px;
     /* --- ADJUSTED: Reduced general shadow for a softer look --- */
-    --shadow-soft: 0 2px 8px rgba(0, 0, 0, 0.04); 
+    --shadow-soft: 0 2px 8px rgba(0, 0, 0, 0.04);
 }
 
 
 
 /* ----------------------------------
-   2. Main Layout Grid
+    2. Main Layout Grid
    ---------------------------------- */
 .mainGrid {
     display: grid;
@@ -76,7 +76,7 @@
 
 
 /* ----------------------------------
-   3. Card & Section Styles
+    3. Card & Section Styles
    ---------------------------------- */
 .card {
     background: var(--bg-primary);
@@ -124,7 +124,7 @@
 }
 
 /* ----------------------------------
-   4. Component Styles (Search, Lists, Seatmap)
+    4. Component Styles (Search, Lists, Seatmap)
    ---------------------------------- */
 
 /* Search Bar */
@@ -189,7 +189,7 @@
     gap: var(--spacing-sm);
     /* --- ADJUSTED: Ensure button stays within the card --- */
     /* Remove padding from the box itself, it's handled by sectionBody */
-    padding: 0; 
+    padding: 0;
     width: 100%; /* Ensure it takes full width of its parent */
     box-sizing: border-box; /* Include padding/border in width */
 }
@@ -282,13 +282,13 @@
     border-color: #C7D2FE;
 }
 /* Remove the direct 'blue' class styling, prefer 'reservable' for consistency */
-/* .block.blue { 
+/* .block.blue {
     background: var(--bg-secondary);
 } */
 
 
 /* ----------------------------------
-   5. Modal Styles
+    5. Modal Styles
    ---------------------------------- */
 .modal-overlay {
     position: fixed;
@@ -345,50 +345,55 @@
 }
 
 /* ----------------------------------
-    5. Notice List Item Styles (NEW)
+    5. Notice List Item Styles (Refined)
    ---------------------------------- */
 
-/* 기존 noticeList 스타일 일부 수정 */
 .noticeList {
     margin: 0;
-    padding: 0; /* padding-left 제거 */
-    font-size: 14px;
-    list-style: none; /* list-style 제거 */
+    padding: 0;
+    list-style: none;
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-xs); /* 항목 간 간격 */
+    gap: 0; /* ✨ gap을 제거하고 padding으로 간격 제어 */
 }
 
 /* 개별 공지사항 링크(a 태그) */
 .noticeList li a {
     display: block;
-    padding: var(--spacing-sm) var(--spacing-md);
+    /* ✨ 상하 여백을 줄여 더 컴팩트하게 만듦 */
+    padding: 10px 12px;
     border-radius: var(--border-radius-sm);
     transition: background-color 0.2s;
     text-decoration: none;
+    border-bottom: 1px solid var(--bg-secondary); /* 항목 간 얇은 구분선 */
+}
+
+.noticeList li:last-child a {
+    border-bottom: none; /* 마지막 항목의 밑줄은 제거 */
 }
 
 .noticeList li a:hover {
-    background-color: var(--bg-secondary); /* 호버 시 배경색 변경 */
-    text-decoration: none; /* 밑줄 제거 유지 */
+    background-color: var(--bg-secondary);
+    text-decoration: none;
 }
 
 /* 공지사항 항목 내부 구조 */
 .notice-item {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-xs); /* 헤더와 제목 사이 간격 */
+    gap: 2px; /* ✨ 헤더와 제목 사이 간격을 미세 조정 */
 }
 
 .notice-header {
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    /* ✨ 세로 정렬 기준을 '중앙'에서 '시작점(위쪽)'으로 변경 */
+    align-items: flex-start;
     font-size: 13px;
     color: var(--text-secondary);
 }
 
-.notice-header span:first-child { /* 아이콘 + 게시판 이름 */
+.notice-header span:first-child {
     display: flex;
     align-items: center;
     gap: var(--spacing-sm);
@@ -397,6 +402,8 @@
 
 .notice-header .date {
     font-size: 12px;
+    white-space: nowrap; /* 날짜가 길어져도 줄바꿈 방지 */
+    margin-left: var(--spacing-sm); /* 제목과 겹치지 않도록 최소 여백 */
 }
 
 .notice-item .title {
@@ -404,7 +411,7 @@
     font-weight: 600;
     color: var(--text-primary);
 
-    /* 제목이 길 경우 한 줄로 표시하고 ... 처리 */
+    /* ✨ 긴 제목이 레이아웃을 깨뜨리지 않도록 처리 */
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/main/resources/templates/classroom/home.html
+++ b/src/main/resources/templates/classroom/home.html
@@ -394,7 +394,13 @@
                             <a th:href="@{/admin/announcement/read(postId=${notice.postId})}">
                                 <div class="notice-item">
                                     <div class="notice-header">
-                                        <span><i class="fa-solid fa-bullhorn"></i> [[${notice.board}]]</span>
+                                        <span th:switch="${notice.board}">
+                                            <i class="fa-solid fa-bullhorn"></i>
+                                            <span th:case="'announcement'">お知らせ</span>
+                                            <span th:case="'announcementIT'">お知らせ - IT</span>
+                                            <span th:case="'announcementJP'">お知らせ - 日本語</span>
+                                            <span th:case="*">[[${notice.board}]]</span>
+                                        </span>
                                         <span class="date">[[${#temporals.format(notice.createdAt, 'MM月 dd日 HH:mm')}]]</span>
                                     </div>
                                     <p class="title">[[${notice.title}]]</p>


### PR DESCRIPTION
This pull request refines the appearance and usability of the notice list on the homepage, focusing on both CSS and template improvements. The main changes are compacting the notice list layout, improving the separation between items, and enhancing the clarity of board names for different types of announcements.

**Notice List UI/UX Refinements:**

* The `noticeList` CSS was updated to remove extra gaps between items, use padding for spacing, and add a thin border between list items for clearer separation. The last item's border is removed for a cleaner look. (`src/main/resources/static/css/home.css`, [src/main/resources/static/css/home.cssL348-R396](diffhunk://#diff-ebf09f06fe17993eb8362715b9978058742babe4ae99ba7267559a77b8d01479L348-R396))
* The padding for each notice item was reduced to make the list more compact, and spacing between header and title within each item was fine-tuned. (`src/main/resources/static/css/home.css`, [src/main/resources/static/css/home.cssL348-R396](diffhunk://#diff-ebf09f06fe17993eb8362715b9978058742babe4ae99ba7267559a77b8d01479L348-R396))
* The alignment of notice headers was changed from center to top-aligned for better visual consistency, and the spacing between icon and board name was preserved. (`src/main/resources/static/css/home.css`, [src/main/resources/static/css/home.cssL348-R396](diffhunk://#diff-ebf09f06fe17993eb8362715b9978058742babe4ae99ba7267559a77b8d01479L348-R396))
* The date in each notice header now prevents wrapping and has a left margin to avoid overlapping with the title. (`src/main/resources/static/css/home.css`, [src/main/resources/static/css/home.cssR405-R414](diffhunk://#diff-ebf09f06fe17993eb8362715b9978058742babe4ae99ba7267559a77b8d01479R405-R414))
* Long notice titles are now properly truncated with ellipsis to prevent layout issues. (`src/main/resources/static/css/home.css`, [src/main/resources/static/css/home.cssR405-R414](diffhunk://#diff-ebf09f06fe17993eb8362715b9978058742babe4ae99ba7267559a77b8d01479R405-R414))

**Announcement Board Name Display:**

* The board name in each notice is now displayed as a user-friendly Japanese label based on its type (e.g., "お知らせ", "お知らせ - IT", "お知らせ - 日本語"), with a fallback to the original value for unknown types. (`src/main/resources/templates/classroom/home.html`, [src/main/resources/templates/classroom/home.htmlL397-R403](diffhunk://#diff-244c602667a79af32e720084a769c6d49c5caeacfb81aaf21b368ea211403be0L397-R403))