### PR TITLE
feat: 헤더 및 공지사항 관련 스타일 수정 및 링크 경로 변경

### DIFF
--- a/src/main/resources/static/css/header.css
+++ b/src/main/resources/static/css/header.css
@@ -37,6 +37,7 @@
     text-decoration: none;
 }
 .navPill .tab.active{ background:var(--primary); color:#fff; }
+.navPill .tab.active:hover{ background:var(--secondary); }
 .navPill .tab:focus-visible{ outline:2px solid var(--primary); outline-offset:2px; }
 
 /** 헤더 하단 간격: 네비게이션 바 아래로 여백을 주어 메인과 분리 */

--- a/src/main/resources/static/css/home.css
+++ b/src/main/resources/static/css/home.css
@@ -94,7 +94,7 @@
 .sectionHead {
     display: block;
     padding: var(--spacing-sm) var(--spacing-md);
-    background: var(--text-primary); /* Bold black header */
+    background: var(--primary);
     color: var(--bg-primary);
     text-decoration: none;
     border-radius: var(--border-radius-md);
@@ -103,7 +103,7 @@
     transition: background-color 0.2s;
 }
 .sectionHead:hover {
-    background-color: #374151; /* Slightly lighter black on hover */
+    background-color: var(--secondary); /* Slightly lighter blue on hover */
 }
 
 .sectionBody {
@@ -345,7 +345,7 @@
 }
 
 /* ----------------------------------
-    5. Notice List Item Styles (Refined)
+    6. Notice List Item Styles (Refined)
    ---------------------------------- */
 
 .noticeList {
@@ -355,6 +355,13 @@
     display: flex;
     flex-direction: column;
     gap: 0; /* ✨ gap을 제거하고 padding으로 간격 제어 */
+}
+
+.noticeList li {
+    margin: 0;
+    max-height: 80px; /* ✨ 각 항목의 최대 높이를 설정하여 균일하게 유지 */
+    /* ✨ 각 항목 사이에 얇은 구분선을 추가 */
+    border-bottom: 1px solid var(--bg-secondary);
 }
 
 /* 개별 공지사항 링크(a 태그) */

--- a/src/main/resources/templates/admin/announcement.html
+++ b/src/main/resources/templates/admin/announcement.html
@@ -114,7 +114,7 @@
                         <ul class="notice-list">
                             <li th:if="${upperPosts.isEmpty()}">お知らせがありません。</li>
                             <li th:each="upperPost : ${upperPosts}">
-                                <a th:href="@{/admin/announcementRead(postId=${upperPost.postId})}">
+                                <a th:href="@{/admin/announcement/read(postId=${upperPost.postId})}">
                                     <span class="title" th:text="${upperPost.title}"></span>
                                     <span class="date" th:text="${#temporals.format(upperPost.createdAt, 'yyyy-MM-dd')}"></span>
                                 </a>
@@ -132,7 +132,7 @@
                         <ul class="notice-list">
                             <li th:if="${lowerPosts.isEmpty()}">お知らせがありません。</li>
                             <li th:each="lowerPost : ${lowerPosts}">
-                                <a th:href="@{/admin/announcementRead(postId=${lowerPost.postId})}">
+                                <a th:href="@{/admin/announcement/read(postId=${lowerPost.postId})}">
                                     <span class="title" th:text="${lowerPost.title}"></span>
                                     <span class="date" th:text="${#temporals.format(lowerPost.createdAt, 'yyyy-MM-dd')}"></span>
                                 </a>

--- a/src/main/resources/templates/admin/announcementRead.html
+++ b/src/main/resources/templates/admin/announcementRead.html
@@ -69,38 +69,13 @@
         <th:block layout:fragment="script">
             <script>
                 $(document).ready(function() {
-                    /**
-                    * 뒤로가기 버튼 이벤트 처리
-                    * - 이전 페이지가 글쓰기, 수정 페이지인 경우 해당 게시판의 목록 페이지로 이동
-                    * - 이전 페이지가 글쓰기, 수정 페이지가 아닌 경우 일반적인 뒤로가기 동작 수행
-                    * - Referrer 정보가 없는 경우(북마크나 URL 직접 입력으로 접속한 경우) 해당 게시판의 목록 페이지로 이동
-                    */
                     $('.back-arrow').click(function(e) {
                         e.preventDefault(); // <a> 태그의 기본 링크 이동 동작 방지
 
                         const listUrl = $(this).data('list-url');
                         const referrer = document.referrer;
 
-                        // 1. 이전 페이지 URL(referrer) 정보가 있는지 확인
-                        if (referrer) {
-                            const previousUrl = new URL(referrer);
-
-                            // 이전 페이지가 글쓰기 페이지('/announcement/write') 또는 수정 페이지('/announcement/update')인 경우
-                            if (previousUrl.pathname.includes('/write') || previousUrl.pathname.includes('/update')) {
-                                // 해당 공지 게시판의 기본 목록 페이지로 이동
-                                location.href = listUrl;
-                            }
-                            // 4. 그 외 다른 페이지에서 넘어온 경우
-                            else {
-                                // 일반적인 뒤로가기 동작 수행
-                                history.back();
-                            }
-                        }
-                        // 5. Referrer 정보가 없는 경우 (북마크나 URL 직접 입력으로 접속한 경우)
-                        else {
-                            // 기본 동작으로 게시판 목록으로 이동
-                            location.href = listUrl;
-                        }
+                        location.href = listUrl;
                     });
                 });
 


### PR DESCRIPTION
This pull request focuses on improving the visual consistency and user experience of the announcement (notice) section, as well as standardizing URL routing in the admin announcement templates. The main changes include updates to CSS for better styling, adjustments to template URLs, and simplification of the back button logic in the announcement read page.

**UI/UX improvements:**

* Updated `.sectionHead` and `.sectionHead:hover` in `home.css` to use `var(--primary)` and `var(--secondary)` for background colors, improving theme consistency. [[1]](diffhunk://#diff-ebf09f06fe17993eb8362715b9978058742babe4ae99ba7267559a77b8d01479L97-R97) [[2]](diffhunk://#diff-ebf09f06fe17993eb8362715b9978058742babe4ae99ba7267559a77b8d01479L106-R106)
* Added a maximum height and a bottom border to each `.noticeList li` item in `home.css` to ensure uniformity and visual separation of notice items.
* Changed the active tab hover background in `header.css` to use `var(--secondary)` for better feedback on navigation.

**Template and routing consistency:**

* Standardized the announcement read URLs in `announcement.html` from `/admin/announcementRead` to `/admin/announcement/read`, improving routing consistency. [[1]](diffhunk://#diff-9037f0204194923ed8b446086d5dc81259e8104015f6bb70997baf1b0586df07L117-R117) [[2]](diffhunk://#diff-9037f0204194923ed8b446086d5dc81259e8104015f6bb70997baf1b0586df07L135-R135)

**Code simplification:**

* Simplified the back button click handler in `announcementRead.html` to always redirect to the list page, removing complex referrer-based logic.