### PR TITLE
fix: 댓글 작성 시 기본 프로필 이미지 경로 수정 및 동적 사용자 아바타 처리 개선

### DIFF
--- a/src/main/resources/static/js/community/controlComments.js
+++ b/src/main/resources/static/js/community/controlComments.js
@@ -53,7 +53,7 @@ function createCommentHTML(comment) {
         </div>
     ` : '';
 
-    const avatarUrl = comment.avatarUrl ? `/scitHub/images/avatar/${comment.avatarUrl}` : "/images/chiikawaPuzzle.png";
+    const avatarUrl = comment.avatarUrl ? `/scitHub/images/avatar/${comment.avatarUrl}` : "/scitHub/images/chiikawaPuzzle.png";
     // DTO의 필드명을 사용하여 HTML을 구성합니다.
     return `
         <div class="comment" data-comment-id="${comment.commentId}">

--- a/src/main/resources/templates/community/readPost.html
+++ b/src/main/resources/templates/community/readPost.html
@@ -95,7 +95,9 @@
 
                         <!-- 댓글 입력 -->
                         <div class="comment-input-section">
-                            <img th:src="@{/images/avatar/{f}(f=${currentUser.avatarUrl})}" alt="私のプロフィールイメージ" class="profile-pic-small">
+                            <img th:src="${#strings.isEmpty(currentUser.avatarUrl)} ? @{/images/chiikawaPuzzle.png} : @{/images/avatar/{f}(f=${currentUser.avatarUrl})}"
+                                alt="私のプロフィールイメージ"
+                                class="profile-pic-small">
                             <div class="comment-input-box">
                                 <input type="text" name="commentForm" id="commentBox" placeholder="コメント作成欄">
                                 <i id="inputCommentBtn" class="fa-solid fa-arrow-up"></i>


### PR DESCRIPTION
This pull request updates how user avatar images are handled in the community comments and post pages to ensure a consistent fallback image is used when a user does not have a custom avatar. The main changes focus on fixing the default avatar path and improving the logic for displaying user profile images.

**Avatar display improvements:**

* In `src/main/resources/static/js/community/controlComments.js`, the fallback avatar path for comments is changed from `/images/chiikawaPuzzle.png` to `/scitHub/images/chiikawaPuzzle.png` to ensure the correct image is shown when `avatarUrl` is missing.
* In `src/main/resources/templates/community/readPost.html`, the logic for displaying the current user's avatar in the comment input section is updated to use `/images/chiikawaPuzzle.png` as the default when `avatarUrl` is empty, otherwise using the user's custom avatar.