### PR TITLE
feat: 모든 알림을 읽음 처리하는 기능 추가 및 UI 개선

### DIFF
--- a/src/main/java/net/dsa/scitHub/controller/NotificationController.java
+++ b/src/main/java/net/dsa/scitHub/controller/NotificationController.java
@@ -1,8 +1,10 @@
 package net.dsa.scitHub.controller;
 
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -47,5 +49,16 @@ public class NotificationController {
         }
 
         return emitter;
+    }
+
+    @PostMapping("/notifications/read/all")
+    public ResponseEntity<Void> markAllAsRead(@AuthenticationPrincipal(expression = "userId") Integer userId) {
+        if (userId == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        ns.markAllAsRead(userId);
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/net/dsa/scitHub/repository/user/NotificationRepository.java
+++ b/src/main/java/net/dsa/scitHub/repository/user/NotificationRepository.java
@@ -25,4 +25,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Inte
      * @return 알림 목록
      */
     List<Notification> findByUserOrderByCreatedAtDesc(User user, Pageable pageable);
+
+    List<Notification> findAllByUserAndIsReadFalse(User user);
 }

--- a/src/main/java/net/dsa/scitHub/service/NotificationService.java
+++ b/src/main/java/net/dsa/scitHub/service/NotificationService.java
@@ -276,4 +276,22 @@ public class NotificationService {
             log.debug("알림 읽음 처리 완료 [notificationId={}]", notificationId);
         }
     }
+
+    /**
+     * 특정 사용자의 모든 알림을 '읽음' 상태로 표시
+     * @param userId 사용자 ID
+     */
+    @Transactional
+    public void markAllAsRead(Integer userId) {
+        User user = User.builder().userId(userId).build();  // 간단히 ID만 가진 User 객체 생성
+
+        // 1. 해당 사용자의 읽지 않은 모든 알림 조회
+        List<Notification> unreadNotifications = nr.findAllByUserAndIsReadFalse(user);
+
+        // 2. 각 알림의 isRead 필드를 true로 설정
+        for (Notification notification : unreadNotifications) {
+            notification.setIsRead(true);
+            log.debug("알림 읽음 처리 완료 [notificationId={}]", notification.getNotificationId());
+        }
+    }
 }

--- a/src/main/resources/static/css/sidebar.css
+++ b/src/main/resources/static/css/sidebar.css
@@ -162,8 +162,8 @@
 }
 
 /* =========================
-   도넛(진행 링) — SVG 벡터 버전 (계단현상 제거)
-   ※ 기존 conic-gradient, ::after 방식 제거
+    도넛(진행 링) — SVG 벡터 버전 (계단현상 제거)
+    ※ 기존 conic-gradient, ::after 방식 제거
    ========================= */
 
 /** 도넛 컨테이너
@@ -332,9 +332,28 @@ body.is-notification-open .notifications-panel {
 .noti-time { color: #9ca3af; font-size: 12px; }
 
 .panel-footer {
-  padding: 16px 20px;
-  text-align: center;
-  border-top: 1px solid #e5e7eb;
-  flex-shrink: 0;
+    padding: 16px 20px;
+    text-align: center;
+    border-top: 1px solid #e5e7eb;
+    flex-shrink: 0;
 }
-.panel-footer a { color: var(--primary); text-decoration: none; font-weight: 600; }
+
+/* a 태그 대신 button 태그를 스타일링하도록 변경 */
+.panel-footer button {
+    width: 100%; /* 너비를 꽉 채워 안정감 부여 */
+    padding: 10px;
+    border-radius: 8px;
+    border: 1px solid var(--border-color);
+    background-color: var(--bg); /* 기본 흰색 배경 */
+    color: var(--muted); /* 기본 회색 텍스트 */
+    font-weight: 600;
+    font-size: 14px;
+    cursor: pointer;
+    transition: all 0.2s ease-in-out;
+}
+
+.panel-footer button:hover {
+    background-color: var(--panel);
+    color: var(--primary);
+    border-color: var(--primary);
+}

--- a/src/main/resources/templates/fragments/notifications.html
+++ b/src/main/resources/templates/fragments/notifications.html
@@ -23,7 +23,7 @@
                 </li>
             </ul>
             <div class="panel-footer">
-                <a th:href="@{/notifications/all}">すべての通知を見る</a>
+                <button type="button" id="mark-all-as-read-btn">すべて既読にする</button>
             </div>
         </div>
     </body>

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -157,9 +157,10 @@
                     const bell = document.getElementById('notification-bell');
                     const panel = document.getElementById('notifications-panel');
                     const closeBtn = document.getElementById('notification-close-btn');
+                    const markAllReadBtn = document.getElementById('mark-all-as-read-btn');
 
                     // UI 요소가 없으면 실행 중지
-                    if (!bell || !panel || !closeBtn) return;
+                    if (!bell || !panel || !closeBtn || !markAllReadBtn) return;
 
                     // 1. 벨 클릭 시 body에 클래스를 추가/제거하여 패널 열기/닫기
                     bell.addEventListener('click', function(e) {
@@ -243,6 +244,26 @@
                             });
                         }
                     });
+
+                    // 5. '모두 읽음 처리' 버튼 클릭 이벤트 리스너 추가
+                    markAllReadBtn.addEventListener('click', function() {
+                        if (!confirm('すべての通知を既読にしますか？')) return;
+
+                        // '모두 읽음' 처리 API의 URL 생성
+                        const baseReadUrl = document.querySelector('[data-read-url]').dataset.readUrl;
+                        const url = `${baseReadUrl}/all`;
+
+                        fetch(url, {
+                            method: 'POST'
+                        }).then(response => {
+                            if (response.ok) {
+                                // 성공 시 UI 업데이트
+                                markAllNotificationsAsReadInUI();
+                            } else {
+                                alert('処理中にエラーが発生しました。');
+                            }
+                        }).catch(error => console.error("'すべて既読'処理中にエラー:", error));
+                    });
                 }
 
                 // 새 알림을 목록에 동적으로 추가하는 함수
@@ -315,6 +336,21 @@
                     interval = seconds / 60;
                     if (interval > 1) return Math.floor(interval) + "分前";
                     return "たった今";
+                }
+
+                // ✨ UI의 모든 알림을 읽음 상태로 변경하는 새 함수
+                function markAllNotificationsAsReadInUI() {
+                    // 1. 모든 'is-unread' 클래스를 가진 li 태그를 찾아 클래스 제거
+                    document.querySelectorAll('.notification-list .is-unread').forEach(li => {
+                        li.classList.remove('is-unread');
+                    });
+
+                    // 2. 뱃지 숫자를 0으로 만들고 숨김
+                    const badge = document.querySelector('.notification-badge');
+                    if (badge) {
+                        badge.textContent = '0';
+                        badge.style.display = 'none';
+                    }
                 }
             /*]]>*/
             </script>


### PR DESCRIPTION
This pull request introduces a "Mark all as read" feature for notifications, allowing users to quickly mark all their unread notifications as read from the UI. The implementation includes backend API changes, repository and service updates, and corresponding UI/UX improvements for a seamless user experience.

**Backend functionality for marking all notifications as read:**

* Added a new `POST /notifications/read/all` endpoint in `NotificationController` to allow users to mark all their notifications as read.
* Implemented the `markAllAsRead` method in `NotificationService`, which sets the `isRead` field to `true` for all unread notifications of a user.
* Extended `NotificationRepository` with a new method `findAllByUserAndIsReadFalse` to efficiently fetch unread notifications for a user.

**UI/UX improvements for notification panel:**

* Replaced the "View all notifications" link with a "Mark all as read" button in `notifications.html`, and updated CSS to style the button for better usability. [[1]](diffhunk://#diff-f32417085199064db4788949a3a8d2758143d6f49b8de65a35013e744d4f692fL26-R26) [[2]](diffhunk://#diff-bbea8d7678e10fbb37a63c6d0867b16b31b64cab0f4eb97624d86425f67301ffL340-R359)
* Added client-side logic in `sidebar.html` to handle the "Mark all as read" button click, trigger the new API, and update the UI accordingly by removing unread markers and resetting the badge count. [[1]](diffhunk://#diff-aa505945e7f46272b109d4013a170e9548a51148d1f21a0361df49bf7dfb4febR160-R163) [[2]](diffhunk://#diff-aa505945e7f46272b109d4013a170e9548a51148d1f21a0361df49bf7dfb4febR247-R266) [[3]](diffhunk://#diff-aa505945e7f46272b109d4013a170e9548a51148d1f21a0361df49bf7dfb4febR340-R354)