### PR TITLE
feat: D-Day 위젯과 관련된 URL 파라미터 추가 및 HTML 구조 개선

### DIFF
--- a/src/main/resources/static/js/homeWidget.js
+++ b/src/main/resources/static/js/homeWidget.js
@@ -1,3 +1,6 @@
+const currentScript = document.currentScript;
+const ddayPageUrl = currentScript.dataset.ddayUrl;
+
 document.addEventListener('DOMContentLoaded', function() {
     initializeDdayWidget();
     initializeCalendarWidget();
@@ -81,9 +84,15 @@ function renderDdayModal(ddayEvents) {
     listEl.innerHTML = ddayEvents.map(dday => {
         const { ddayString, targetDate } = calculateDday(dday.dday);
         const formattedDate = targetDate.toLocaleDateString('ja-JP');
+
+        const editUrl = `${ddayPageUrl}?action=edit&id=${dday.ddayId}`;
+
         return `<li>
                     <input type="checkbox" data-id="${dday.ddayId}" ${dday.pinned ? 'checked' : ''}>
-                    <div class="dday-info"><div class="dday-title">${dday.title}</div><div class="dday-date">${formattedDate}</div></div>
+                    <div class="dday-info">
+                        <a class="dday-title" href="${editUrl}">${dday.title}</a>
+                        <div class="dday-date">${formattedDate}</div>
+                    </div>
                     <div class="dday-counter">${ddayString}</div>
                 </li>`;
     }).join('');

--- a/src/main/resources/templates/calendar/dDay.html
+++ b/src/main/resources/templates/calendar/dDay.html
@@ -3,7 +3,6 @@
     xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
     layout:decorate="~{layouts/defaultLayout}">
     <head>
-        
         <title>D-Day</title>
         <th:block layout:fragment="css">
             <!-- 밑에 줄 home.css는 지워야 하는 부분 -->
@@ -398,7 +397,7 @@
     </head>
     <body>
         <section class="mainGrid" aria-label="메인 영역" layout:fragment="content">
-                 <!-- 메인 디데이 영역 -->
+                <!-- 메인 디데이 영역 -->
             <main class="main-content">
                 <div class="dday-container">
                     <div class="dday-header">
@@ -421,12 +420,12 @@
                         <label for="ddayTitle">タイトル</label>
                         <input type="text" id="ddayTitle" name="title" placeholder="例:プロジェクト発表" required>
                     </div>
-                    
+
                     <div class="form-group">
                         <label for="ddayDate">目標日</label>
                         <input type="date" id="ddayDate" name="date" required>
                     </div>
-                    
+
                     <div class="modal-buttons">
                         <button type="button" class="btn btn-secondary" id="cancelBtn">キャンセル</button>
                         <button type="button" class="btn btn-danger" id="deleteBtn" style="display: none;">削除</button>
@@ -513,7 +512,7 @@
                         } else {
                             ddayClass = 'today';    // 오늘
                             ddayText = 'D-Day';
-                        } 
+                        }
 
                         // 최종적으로 생성될 카드의 HTML 구조를 반환합니다.
                         return `
@@ -575,7 +574,7 @@
                      * 서버에서 모든 디데이 목록을 가져와 화면에 렌더링
                     */
                     async function fetchAndRenderDdays() {
-                        try { 
+                        try {
                             const response = await fetch('/scitHub/api/ddays') // 명시하지 않으면 기본 GET 요청
                             if (!response.ok) {
                                 throw new Error('D-Dayリストの読み込みに失敗しました.');
@@ -587,6 +586,24 @@
                             const ddayCards = ddays.map(dday => createDdayCard(dday)).join('');
                             const addCard = createAddDdayCard();
                             ddayGrid.innerHTML = ddayCards + addCard;
+
+                            // 페이지 로딩 후 URL 파라미터를 확인하여 수정 모달을 바로 엽니다.
+                            const urlParams = new URLSearchParams(window.location.search);
+                            const action = urlParams.get('action');
+                            const ddayId = urlParams.get('id');
+
+                            if (action === 'edit' && ddayId) {
+                                console.log('Opening edit modal for ddayId:', ddayId);
+                                const cardToEdit = document.querySelector(`.dday-card[data-dday-id="${ddayId}"]`);
+                                if (cardToEdit) {
+                                    const ddayData = {
+                                        ddayId: cardToEdit.dataset.ddayId,
+                                        title: cardToEdit.dataset.title,
+                                        date: cardToEdit.dataset.date,
+                                    };
+                                    openModal('edit', ddayData);
+                                }
+                            }
                         } catch (error) {
                             console.error('Render Error:', error);
                             alert(error.message);
@@ -698,6 +715,16 @@
                     }
 
                     /**
+                     * URL 파라미터 제거
+                     * 모달이 닫힐 때 URL에서 action과 id 파라미터를 제거하여
+                     * 새로고침 시 모달이 다시 열리는 것을 방지합니다.
+                    */
+                    function clearUrlParams() {
+                        const cleanUrl = window.location.protocol + "//" + window.location.host + window.location.pathname;
+                        window.history.replaceState({path: cleanUrl}, '', cleanUrl);
+                    }
+
+                    /**
                      * 모달 닫기
                     */
                     function closeModal() {
@@ -709,10 +736,12 @@
                         ddayForm.reset();
                         deleteBtn.style.display = 'none';
                         modalTitle.textContent = 'D-Day 追加';
+
+                        // URL 파라미터 제거
+                        clearUrlParams();
                     }
 
                     // -- 이벤트 리스너 ----
-                    
                     // 취소버튼 클릭시 모달 숨김
                     cancelBtn.addEventListener('click', function(){
                         closeModal();
@@ -734,7 +763,6 @@
 
                     // 디데이 카드 영역에 이벤트 등록 (목록에서 각 카드의 아이콘 누르는 상황)
                     ddayGrid.addEventListener('click', function(event) {
-                        
                         // 수정
                         // 클릭된 요소(target)에서 가장 가까운 .btn-edit를 찾음
                         const editButton = event.target.closest('.btn-edit');

--- a/src/main/resources/templates/classroom/home.html
+++ b/src/main/resources/templates/classroom/home.html
@@ -274,7 +274,7 @@
             <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.19/index.global.min.js"></script>
             <script th:src="@{/js/reservation.js}"></script>
             <script th:src="@{/js/scheduleModal.js}"></script>
-            <script th:src="@{/js/homeWidget.js}"></script>
+            <script th:src="@{/js/homeWidget.js}" th:data-dday-url="@{/calendar/dDay}"></script>
         </th:block>
     </body>
 </html>


### PR DESCRIPTION
This pull request introduces improvements to the D-Day widget and its modal behavior, focusing on better navigation and user experience when editing D-Day events. The main changes enable direct linking to the D-Day edit modal via URL parameters, ensure the modal opens automatically when appropriate, and clean up the URL after the modal is closed to prevent unintended reopening.

**D-Day Widget and Modal Improvements**

* Added support for passing the D-Day page URL to the `homeWidget.js` script via a custom data attribute, enabling dynamic construction of edit links for each D-Day event. [[1]](diffhunk://#diff-244c602667a79af32e720084a769c6d49c5caeacfb81aaf21b368ea211403be0L277-R277) [[2]](diffhunk://#diff-0bedf9bbe775afb068a1ca20cbe9a8860b75fb1b747d7f7baadc9e6c62ffd3c3R1-R3)
* Modified the D-Day event list in the modal to display each event title as an edit link, which navigates to the D-Day page with `action=edit` and the corresponding event ID as URL parameters.

**Edit Modal Behavior Enhancements**

* Implemented logic to automatically open the D-Day edit modal when the page loads and the URL contains `action=edit` and a valid event ID, allowing direct navigation to edit specific events.
* Added a utility function to remove URL parameters (`action` and `id`) when the modal is closed, preventing the modal from reopening unintentionally on page refresh. This function is called whenever the modal is closed. [[1]](diffhunk://#diff-3723c13b37f57764d8183e6bb8ebf29127e9d13a77306eccab754e368967b818R717-R726) [[2]](diffhunk://#diff-3723c13b37f57764d8183e6bb8ebf29127e9d13a77306eccab754e368967b818R739-L715)

**Minor Code Cleanup**

* Removed unnecessary whitespace and improved code formatting in event listener sections for better readability.