### PR TITLE
feat: 인스타그램 피드 표시 개선 및 최신 게시물 수 증가

### DIFF
--- a/src/main/java/net/dsa/scitHub/service/InstagramService.java
+++ b/src/main/java/net/dsa/scitHub/service/InstagramService.java
@@ -33,7 +33,7 @@ public class InstagramService {
                 log.info("인스타그램에서 {}개의 게시물을 성공적으로 가져왔습니다.", response.getData().size());
 
                 return response.getData().stream()
-                        .limit(5) // 최신 5개 게시물만 반환
+                        .limit(6) // 최신 6개 게시물만 반환
                         .collect(Collectors.toList());  // 다시 리스트로 변환
             }
         } catch (Exception e) {

--- a/src/main/resources/static/css/home.css
+++ b/src/main/resources/static/css/home.css
@@ -51,13 +51,43 @@
     padding: var(--spacing-xl);
     max-width: 1440px;
     margin: 0 auto;
-    align-items: start;
+    align-items: stretch;
 }
 
 .leftCol, .centerCol, .rightCol {
     display: flex;
     flex-direction: column;
     gap: var(--spacing-lg);
+}
+
+/* leftCol의 마지막 카드(게시판 카테고리)가 남은 공간을 모두 차지하도록 함 */
+.leftCol .stackCard:last-child {
+    flex-grow: 1; /* ✨ 1. 남은 공간을 모두 차지 */
+    display: flex;
+    flex-direction: column;
+}
+
+/* sectionBody와 그 안의 nav 태그가 높이를 100% 채우도록 설정 */
+.leftCol .stackCard:last-child .sectionBody,
+.leftCol .stackCard:last-child .sectionBody nav {
+    max-height: 100%;
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+/* ✨ 1. centerCol 안의 두 번째 카드(인스타그램 피드)가 남은 공간을 모두 차지하도록 설정 */
+.centerCol .stackCard.instagramCard {
+    flex-grow: 1; /* 남은 수직 공간을 모두 차지 */
+    display: flex;
+    flex-direction: column;
+}
+
+/* ✨ 2. 카드 본문과 피드 컨테이너도 높이를 100% 채우도록 설정 */
+.centerCol .stackCard.instagramCard .sectionBody,
+.centerCol .stackCard.instagramCard .instagram-feed {
+    flex-grow: 1;
+    height: 100%; /* 추가적으로 높이를 100%로 설정하여 확실하게 채움 */
 }
 
 /* Responsive adjustments */
@@ -433,9 +463,12 @@
 
 /* 게시판 카테고리 영역 크기 */
 .boardList {
-    width: 100%;
-    max-height: 300px;  /* 최대 높이 */
-    overflow: auto;     /* 가로, 세로 크기 초과 시 스크롤로 */
+    overflow-y: auto;   /* 내용이 넘칠 경우 스크롤 생성 */
+    /* 기존 flex 관련 속성들은 유지해도 괜찮습니다. */
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    max-height: 100%; /* 부모 요소의 높이를 최대한 활용 */
 }
 
 /* 각 카테고리 스타일 */
@@ -462,6 +495,15 @@
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); /* 화면 크기에 따라 열 개수 조절 */
     gap: 16px;
+    overflow-y: auto; /* 내용이 넘칠 경우 스크롤 생성 */
+    height: 100%; /* 부모 요소의 높이를 최대한 활용 */
+    padding: 8px;
+    box-sizing: border-box; /* 패딩이 전체 크기에 포함되도록 설정 */
+    /* 배경색과 테두리 추가로 카드 느낌 강조 */
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius-md);
+    box-shadow: var(--shadow-soft);
 }
 .insta-post {
     position: relative;

--- a/src/main/resources/templates/classroom/home.html
+++ b/src/main/resources/templates/classroom/home.html
@@ -115,23 +115,25 @@
                         <div class="block"       style="grid-column:14 / span 3; grid-row:9 / span 2; border-radius:22px;">講義室9</div>
                     </div>
                 </section>
-                <div class="sectionBody">
-                    <!-- 인스타그램 피드 -->
-                    <div class="instagram-feed">
-                        <p th:if="${#lists.isEmpty(instagramPosts)}">
-                            インスタグラム投稿を読み込むことができません。
-                        </p>
-                        <a th:each="post : ${instagramPosts}" th:href="${post.permalink}" target="_blank" class="insta-post">
-                            <img th:src="${post.mediaUrl}" th:alt="${post.caption}" />
-                            <div class="instagram-icon-overlay">
-                                <i class="fa-brands fa-instagram"></i>
-                            </div>
-                            <div class="caption-overlay">
-                                <p th:text="${post.caption}"></p>
-                            </div>
-                        </a>
+                <!-- 인스타그램 피드 -->
+                <section class="stackCard instagramCard" aria-label="인스타그램 피드">
+                    <div class="sectionBody">
+                        <div class="instagram-feed">
+                            <p th:if="${#lists.isEmpty(instagramPosts)}">
+                                インスタグラム投稿を読み込むことができません。
+                            </p>
+                            <a th:each="post : ${instagramPosts}" th:href="${post.permalink}" target="_blank" class="insta-post">
+                                <img th:src="${post.mediaUrl}" th:alt="${post.caption}" />
+                                <div class="instagram-icon-overlay">
+                                    <i class="fa-brands fa-instagram"></i>
+                                </div>
+                                <div class="caption-overlay">
+                                    <p th:text="${post.caption}"></p>
+                                </div>
+                            </a>
+                        </div>
                     </div>
-                </div>
+                </section>
             </div>
 
             <!-- 우: 디데이 + 일정 (2단 블록) -->


### PR DESCRIPTION
This pull request improves the layout and responsiveness of the homepage, particularly focusing on better use of vertical space and scroll behavior for the Instagram feed and board category sections. It also updates the backend to show one more Instagram post. The most important changes are grouped below by theme.

**Layout and Responsiveness Improvements:**

* Updated the `.mainGrid` and column/card CSS to use `align-items: stretch` and added `flex-grow` properties, ensuring that the last card in `.leftCol` and the Instagram feed card in `.centerCol` expand to fill available vertical space. Section bodies and inner containers now also fill their parent height. [[1]](diffhunk://#diff-ebf09f06fe17993eb8362715b9978058742babe4ae99ba7267559a77b8d01479L54-R54) [[2]](diffhunk://#diff-ebf09f06fe17993eb8362715b9978058742babe4ae99ba7267559a77b8d01479R63-R92)
* Modified `.boardList` and `.insta-posts-container` styles to use `overflow-y: auto` and `max-height: 100%`, allowing these areas to scroll and fully utilize their parent containers. Added padding, background, border, and shadow to enhance the card appearance. [[1]](diffhunk://#diff-ebf09f06fe17993eb8362715b9978058742babe4ae99ba7267559a77b8d01479L436-R471) [[2]](diffhunk://#diff-ebf09f06fe17993eb8362715b9978058742babe4ae99ba7267559a77b8d01479R498-R506)
* Updated the homepage template to wrap the Instagram feed in a dedicated section with the new card class, aligning the markup with the improved CSS for layout consistency. [[1]](diffhunk://#diff-244c602667a79af32e720084a769c6d49c5caeacfb81aaf21b368ea211403be0L118-R120) [[2]](diffhunk://#diff-244c602667a79af32e720084a769c6d49c5caeacfb81aaf21b368ea211403be0R136)

**Backend Functionality Update:**

* Increased the number of recent Instagram posts returned from 5 to 6 in the `InstagramService`, allowing the frontend to display one additional post.