### PR TITLE
feat: 알림 기능 개선 및 공지사항 추가

### DIFF
--- a/src/main/java/net/dsa/scitHub/enums/NotificationType.java
+++ b/src/main/java/net/dsa/scitHub/enums/NotificationType.java
@@ -9,7 +9,8 @@ public enum NotificationType {
     NEW_LIKE_ON_POST("あなたの投稿に新しい「いいね！」が付きました。"),
     NEW_COMMENT_ON_POST("あなたの投稿に新しいコメントがありました。"),
     NEW_MESSAGE("新しいメッセージが届きました。"),
-    NEW_EVENT("全体スケジュールが登録されました。");
+    NEW_EVENT("全体スケジュールが登録されました。"),
+    NEW_ANNOUNCEMENT("新しいお知らせが投稿されました。");
 
     private final String title;
 }

--- a/src/main/java/net/dsa/scitHub/repository/user/UserRepository.java
+++ b/src/main/java/net/dsa/scitHub/repository/user/UserRepository.java
@@ -109,7 +109,7 @@ public interface UserRepository extends JpaRepository<User, Integer> {
     @Query("SELECT DISTINCT u.cohortNo FROM User u WHERE u.cohortNo IS NOT NULL ORDER BY u.cohortNo DESC")
     List<Integer> findDistinctCohortNos();
 
-    // userId가 특정 값이 아닌 모든 사용자 조회
-    List<User> findByUserIdNot(Integer userId);
+    // userId가 특정 값이 아니면서 활성화되어 있는 모든 사용자 조회
+    List<User> findByUserIdNotAndIsActiveTrue(Integer userId);
 }
 

--- a/src/main/java/net/dsa/scitHub/service/EventService.java
+++ b/src/main/java/net/dsa/scitHub/service/EventService.java
@@ -70,7 +70,7 @@ public class EventService {
         // 알림 전송
         // 생성자가 관리자이고, 생성된 일정이 전체 공개(PUBLIC) 일정인 경우에만 알림 전송
         if (isAdmin && savedEvent.getVisibility() == Visibility.PUBLIC) {
-            List<User> allUsersExceptCreator = ur.findByUserIdNot(eventUser.getUserId());
+            List<User> allUsersExceptCreator = ur.findByUserIdNotAndIsActiveTrue(eventUser.getUserId());
             for (User recipient : allUsersExceptCreator) {
                 ns.send(recipient, NotificationType.NEW_EVENT, savedEvent);
             }

--- a/src/main/java/net/dsa/scitHub/service/NotificationService.java
+++ b/src/main/java/net/dsa/scitHub/service/NotificationService.java
@@ -87,6 +87,11 @@ public class NotificationService {
             // if (post.getUser().equals(recipient)) {
             //     return null;
             // }
+            // 만약 게시물이 공지사항이고, 작성자가 수신자라면 알림 생성하지 않음
+            if (List.of("announcement", "announcementIT", "announcementJP").contains(post.getBoard().getName())
+                && post.getUser().equals(recipient)) {
+                return null;
+            }
             String content = createNotificationContent(type, entity);
             String url = createNotificationUrl(type, entity);
 
@@ -183,6 +188,12 @@ public class NotificationService {
                 String eventContent = "タイトル: " + event.getTitle();
                 yield checkContentLength(eventContent, 30);
             }
+            case NEW_ANNOUNCEMENT -> {
+                String announcementName = ((Post) entity).getBoard().getName();
+                String announcementContent = announcementName.equals("announcement") ? "お知らせ - " : announcementName.equals("announcementIT") ? "ITお知らせ - " : "日本語お知らせ - ";
+                announcementContent += ((Post) entity).getTitle();
+                yield checkContentLength(announcementContent, 30);
+            }
         };
     }
 
@@ -215,6 +226,10 @@ public class NotificationService {
             }
             case NEW_MESSAGE -> "/mypage/messages";
             case NEW_EVENT -> "/calendar/schedule";
+            case NEW_ANNOUNCEMENT -> {
+                Post post = (Post) entity;
+                yield resolvePostUrlByBoard(post);
+            }
         };
     }
 
@@ -226,6 +241,14 @@ public class NotificationService {
     private String resolvePostUrlByBoard(Post post) {
         if (post.getBoard().getBoardId() == br.findByName("inquiry").get().getBoardId()) {
             return "/admin/inquiryRead?postId=" + post.getPostId();
+        } else if (
+            List.of(
+                br.findByName("announcement").get().getBoardId(),
+                br.findByName("announcementIT").get().getBoardId(),
+                br.findByName("announcementJP").get().getBoardId()
+            ).contains(post.getBoard().getBoardId())
+        ) {
+            return "/admin/announcement/read?postId=" + post.getPostId();
         } else {
             return "/community/readPost?postId=" + post.getPostId();
         }

--- a/src/main/resources/templates/fragments/notifications.html
+++ b/src/main/resources/templates/fragments/notifications.html
@@ -7,9 +7,6 @@
                 <button type="button" id="notification-close-btn" title="閉じる">&times;</button>
             </div>
             <ul class="notification-list" id="notification-list">
-                <li th:if="${notifications == null or #lists.isEmpty(notifications)}" class="no-notifications">
-                    <p>新しい通知はありません。</p>
-                </li>
                 <li th:each="noti : ${notifications}" th:classappend="${!noti.isRead} ? 'is-unread' : ''"
                     th:data-notification-id="${noti.notificationId}">
                     <a th:href="@{${noti.targetUrl}}" class="notification-link" th:data-notification-id="${noti.notificationId}">


### PR DESCRIPTION
This pull request introduces support for announcement notifications, ensuring that users receive alerts when new announcements are posted, and refines notification delivery logic for events and announcements. The changes affect notification types, notification content and URLs, and the logic for sending notifications to users.

### Announcement notification feature

* Added a new notification type, `NEW_ANNOUNCEMENT`, to the `NotificationType` enum to represent new announcement notifications.
* Implemented logic in `PostService.savePostAndReturnEntity` to send `NEW_ANNOUNCEMENT` notifications to all active users except the author when a post is made in any announcement board.
* Updated notification content and URL generation to support `NEW_ANNOUNCEMENT`, including distinguishing between different announcement boards and resolving the correct URL for announcement posts. [[1]](diffhunk://#diff-a066eff8ba22d2c59f382cd4696402ad84c4528133db095929d773e0ebb7a910R191-R196) [[2]](diffhunk://#diff-a066eff8ba22d2c59f382cd4696402ad84c4528133db095929d773e0ebb7a910R229-R232) [[3]](diffhunk://#diff-a066eff8ba22d2c59f382cd4696402ad84c4528133db095929d773e0ebb7a910R244-R251)

### Notification delivery improvements

* Modified user repository and event notification logic to ensure notifications are sent only to active users (excluding the creator) for both events and announcements. [[1]](diffhunk://#diff-61d2f3a84e15bc3bd6b3f2d327b7060194fea7e7b0972a55bda4d0f0da760697L112-R113) [[2]](diffhunk://#diff-5ae87fe21487bb89960251297a405631350deeecb57b98aa1966665f180d1bc2L73-R73)
* Improved notification creation logic to prevent sending announcement notifications to the author of the announcement.