### PR TITLE
fix: 프로필 사진 스타일에 object-fit 속성 추가

### DIFF
--- a/src/main/resources/static/css/community/readPost.css
+++ b/src/main/resources/static/css/community/readPost.css
@@ -47,8 +47,8 @@
 }
 
 /* 프로필 사진 공통 스타일 */
-.profile-pic { width: 42px; height: 42px; border-radius: 50%; }
-.profile-pic-small { width: 34px; height: 34px; border-radius: 50%; }
+.profile-pic { width: 42px; height: 42px; border-radius: 50%; object-fit: cover; }
+.profile-pic-small { width: 34px; height: 34px; border-radius: 50%; object-fit: cover; }
 
 /* --- 게시글 상단 --- */
 .post-header {


### PR DESCRIPTION
This pull request makes a small update to the profile picture styling in the community post CSS file. The change ensures that profile images are displayed consistently by covering the image area within their containers.

* Added `object-fit: cover;` to both `.profile-pic` and `.profile-pic-small` classes for better image cropping and presentation.