### PR TITLE
feat: 코스 리뷰 경로를 변경하여 더 명확한 URL 구조로 개선

### DIFF
--- a/src/main/java/net/dsa/scitHub/controller/CommunityController.java
+++ b/src/main/java/net/dsa/scitHub/controller/CommunityController.java
@@ -468,7 +468,7 @@ public class CommunityController {
      * @param model
      * @return courseReview.html
      */
-    @GetMapping("courseReview")
+    @GetMapping("courseList/readReview")
     public String courseReview(
         @RequestParam(name="id", required=true) Integer courseId,
         Model model,

--- a/src/main/resources/templates/community/courseList.html
+++ b/src/main/resources/templates/community/courseList.html
@@ -12,20 +12,20 @@
         <section class="mainGrid" aria-label="메인 영역" layout:fragment="content">
             <div class="container">
                 <!-- 검색바 -->
-                 <div class="search-box">
+                <div class="search-box">
                     <form th:action="@{/community/courseList}" method="get">
                         <i class="fa fa-search"></i>
                         <input type="text" name="name" placeholder="コース名で探す">
                         <button type="submit" style="display: none;"></button>
                     </form>
-                 </div>
+                </div>
 
                 <!-- 일본어 수업 -->
                 <div class="section">
                     <div class="section-title">日本語</div>
                     <div class="card-container">
                         <th:block th:each="course : ${courseList}" th:if="${course.courseType.name() == 'JP'}">
-                            <a th:href="@{/community/courseReview(id=${course.courseId})}" class="card-link" style="text-decoration: none; color: inherit;">
+                            <a th:href="@{/community/courseList/readReview(id=${course.courseId})}" class="card-link" style="text-decoration: none; color: inherit;">
                                 <div class="card">
                                     <h4 th:text="${course.name}">Course</h4>
                                     <p th:text="${course.instructorName}">Professor</p>
@@ -47,7 +47,7 @@
                     <div class="section-title">IT</div>
                     <div class="card-container">
                         <th:block th:each="course : ${courseList}" th:if="${course.courseType.name() == 'IT'}">
-                            <a th:href="@{/community/courseReview(id=${course.courseId})}" class="card-link" style="text-decoration: none; color: inherit;">
+                            <a th:href="@{/community/courseList/readReview(id=${course.courseId})}" class="card-link" style="text-decoration: none; color: inherit;">
                                 <div class="card">
                                     <h4 th:text="${course.name}">Course</h4>
                                     <p th:text="${course.instructorName}">Professor</p>


### PR DESCRIPTION
This pull request updates the URL mapping for the course review feature to use a more descriptive path. The main change is renaming the endpoint from `courseReview` to `courseList/readReview` throughout both the controller and the HTML template, ensuring consistency and improving clarity in navigation.

Routing update:

* Changed the `@GetMapping` annotation in `CommunityController.java` from `courseReview` to `courseList/readReview`, updating the method route for fetching course reviews.

Template link updates:

* Updated all links in `courseList.html` that previously pointed to `/community/courseReview` to now use `/community/courseList/readReview`, ensuring that users are directed to the new endpoint when viewing reviews for Japanese and IT courses. [[1]](diffhunk://#diff-8c6989521acb9fd8c0e11e29abae86c8b49b2cde4703f9c46e8da107af056875L28-R28) [[2]](diffhunk://#diff-8c6989521acb9fd8c0e11e29abae86c8b49b2cde4703f9c46e8da107af056875L50-R50)